### PR TITLE
docs: add Privacy Policy for Microsoft Store submission

### DIFF
--- a/privacy.md
+++ b/privacy.md
@@ -89,21 +89,82 @@ If you have questions or concerns about this Privacy Policy, please open an issu
 
 **最後更新：** 2026-04-02
 
-CmdPalTranslator 是一個 Windows Command Palette 翻譯擴充功能。本應用程式透過 Bing 與 Google 翻譯服務執行文字翻譯。
+CmdPalTranslator 是一個 Windows Command Palette 翻譯擴充功能，透過 Bing 與 Google 翻譯服務執行文字翻譯。本隱私權政策說明本應用程式存取哪些資訊、如何使用，以及您身為使用者的相關權利。
 
-### 資料收集與使用
+---
 
-- 您輸入的**文字內容**與**語言設定**會直接傳送至所選的第三方翻譯服務（Bing 或 Google），僅用於執行翻譯。開發者不保留任何翻譯紀錄。
-- **預設目標語言** 儲存於您裝置上應用程式的私有儲存空間中，僅包含語言代碼，不會傳送至任何伺服器。
-- 本應用程式**不收集**任何個人識別資訊、裝置識別碼、使用記錄、診斷遙測或位置資料。
+### 1. 我們收集的資訊
 
-### 第三方服務
+#### 您提供的資訊
 
-翻譯請求由 Bing（Microsoft）或 Google 處理。請參閱其各自的隱私權政策：
+當您使用 CmdPalTranslator 進行翻譯時，下列資料會被暫時處理：
 
-- [Microsoft 隱私權聲明](https://privacy.microsoft.com/privacystatement)
-- [Google 隱私權政策](https://policies.google.com/privacy)
+- **來源文字** — 您在 Command Palette 中輸入的待翻譯文字。
+- **語言選擇** — 來源語言（自動偵測或手動指定）與目標語言代碼。
 
-### 聯絡方式
+此資料會直接傳送至您所選的第三方翻譯服務（Bing 或 Google），僅用於執行翻譯。**本應用程式與開發者均不保留任何文字輸入或翻譯結果。**
 
-如有任何疑問，請至 GitHub 開立 Issue：[https://github.com/poychang/CmdPalTranslator](https://github.com/poychang/CmdPalTranslator)
+#### 本機儲存的偏好設定
+
+本應用程式僅在您的裝置上儲存一項偏好設定：
+
+- **預設目標語言** — 儲存於您裝置上應用程式的私有儲存空間中，僅包含語言代碼（例如繁體中文為 `zht`），不會傳送至任何伺服器。
+
+---
+
+### 2. 我們不收集的資訊
+
+CmdPalTranslator 的開發者**不**收集、儲存或傳送：
+
+- 個人識別資訊（姓名、電子郵件、帳號憑證）
+- 裝置識別碼或硬體指紋
+- 使用記錄、搜尋記錄或翻譯日誌
+- 當機報告或診斷遙測資料
+- 位置資料
+
+---
+
+### 3. 第三方服務
+
+為執行翻譯，CmdPalTranslator 會代表您連線至下列外部服務：
+
+| 服務 | 端點 | 隱私權政策 |
+|------|------|------------|
+| **Microsoft Bing 翻譯** | `https://www.bing.com/translator` | [Microsoft 隱私權聲明](https://privacy.microsoft.com/privacystatement) |
+| **Google 翻譯** | `https://translate.googleapis.com` | [Google 隱私權政策](https://policies.google.com/privacy) |
+
+當您發起翻譯時，輸入文字與語言代碼會直接傳送至所選服務。開發者無法控制第三方處理資料的方式，請參閱其各自的隱私權政策。
+
+---
+
+### 4. 網際網路連線
+
+CmdPalTranslator 需要網際網路存取權限，專門用於呼叫 Bing 與 Google 翻譯 API，本應用程式不會建立其他任何對外網路連線。
+
+---
+
+### 5. 資料保留
+
+- **翻譯輸入**不會被本應用程式保留。翻譯結果顯示後，輸入與輸出內容均不留存任何副本。
+- **語言偏好設定**儲存於裝置本機，直到您更改設定或解除安裝應用程式為止。
+
+---
+
+### 6. 兒童隱私
+
+CmdPalTranslator 不會故意收集 13 歲以下兒童的任何個人資訊。若您認為兒童透過翻譯請求提供了個人資料，請直接聯絡相關第三方服務（Bing 或 Google），因為資料係由其單獨處理。
+
+---
+
+### 7. 政策變更
+
+本隱私權政策可能因應用程式功能變更或法規要求而更新。更新內容將發布於本文件，並修訂「最後更新」日期。繼續使用本應用程式即表示接受修訂後的政策。
+
+---
+
+### 8. 聯絡方式
+
+如對本隱私權政策有任何疑問，請至專案儲存庫開立 Issue：
+
+**GitHub：** [https://github.com/poychang/CmdPalTranslator](https://github.com/poychang/CmdPalTranslator)
+

--- a/privacy.md
+++ b/privacy.md
@@ -23,9 +23,7 @@ This data is transmitted directly to the selected third-party translation servic
 
 The application stores a single preference on your device:
 
-- **Default target language** — saved as a plain text file (`default-target-language.txt`) in the application's sandboxed local data folder managed by Windows (under `%LocalAppData%\Packages\`).
-
-This file contains only a language code (e.g., `zht` for Traditional Chinese). It remains on your device within the app's private storage and is never transmitted to any server.
+- **Default target language** — saved locally in the application's private storage on your device. This file contains only a language code (e.g., `zht` for Traditional Chinese) and is never transmitted to any server.
 
 ---
 
@@ -96,7 +94,7 @@ CmdPalTranslator 是一個 Windows Command Palette 翻譯擴充功能。本應�
 ### 資料收集與使用
 
 - 您輸入的**文字內容**與**語言設定**會直接傳送至所選的第三方翻譯服務（Bing 或 Google），僅用於執行翻譯。開發者不保留任何翻譯紀錄。
-- **預設目標語言** 以純文字檔（`default-target-language.txt`）儲存於 Windows 為此應用程式管理的沙箱化本機資料夾中（位於 `%LocalAppData%\Packages\` 底下）。此設定不會傳送至任何伺服器。
+- **預設目標語言** 儲存於您裝置上應用程式的私有儲存空間中，僅包含語言代碼，不會傳送至任何伺服器。
 - 本應用程式**不收集**任何個人識別資訊、裝置識別碼、使用記錄、診斷遙測或位置資料。
 
 ### 第三方服務

--- a/privacy.md
+++ b/privacy.md
@@ -23,9 +23,9 @@ This data is transmitted directly to the selected third-party translation servic
 
 The application stores a single preference on your device:
 
-- **Default target language** — saved to `%LocalAppData%\CmdPalTranslator\default-target-language.txt`.
+- **Default target language** — saved as a plain text file (`default-target-language.txt`) in the application's sandboxed local data folder managed by Windows (under `%LocalAppData%\Packages\`).
 
-This file contains only a language code (e.g., `zht` for Traditional Chinese). It remains on your device and is never transmitted to any server.
+This file contains only a language code (e.g., `zht` for Traditional Chinese). It remains on your device within the app's private storage and is never transmitted to any server.
 
 ---
 
@@ -96,7 +96,7 @@ CmdPalTranslator 是一個 Windows Command Palette 翻譯擴充功能。本應�
 ### 資料收集與使用
 
 - 您輸入的**文字內容**與**語言設定**會直接傳送至所選的第三方翻譯服務（Bing 或 Google），僅用於執行翻譯。開發者不保留任何翻譯紀錄。
-- 本應用程式僅在您的裝置上本機儲存一項設定：**預設目標語言**（`%LocalAppData%\CmdPalTranslator\default-target-language.txt`）。此設定不會傳送至任何伺服器。
+- **預設目標語言** 以純文字檔（`default-target-language.txt`）儲存於 Windows 為此應用程式管理的沙箱化本機資料夾中（位於 `%LocalAppData%\Packages\` 底下）。此設定不會傳送至任何伺服器。
 - 本應用程式**不收集**任何個人識別資訊、裝置識別碼、使用記錄、診斷遙測或位置資料。
 
 ### 第三方服務

--- a/privacy.md
+++ b/privacy.md
@@ -1,0 +1,111 @@
+# Privacy Policy — CmdPalTranslator
+
+**Last Updated:** 2026-04-02
+
+## Overview
+
+CmdPalTranslator is a Windows Command Palette extension that provides text translation using Bing and Google translation services. This Privacy Policy describes what information the application accesses, how it is used, and your rights as a user.
+
+---
+
+## 1. Information We Collect
+
+### Information You Provide
+
+When you use CmdPalTranslator to translate text, the following data is temporarily processed:
+
+- **Source text** — the text you type into the Command Palette for translation.
+- **Language selection** — the source language (auto-detected or specified) and target language code.
+
+This data is transmitted directly to the selected third-party translation service (Bing or Google) solely to perform the translation. **No text input or translation results are stored by this application or by the developer.**
+
+### Locally Stored Preferences
+
+The application stores a single preference on your device:
+
+- **Default target language** — saved to `%LocalAppData%\CmdPalTranslator\default-target-language.txt`.
+
+This file contains only a language code (e.g., `zht` for Traditional Chinese). It remains on your device and is never transmitted to any server.
+
+---
+
+## 2. Information We Do NOT Collect
+
+The developer of CmdPalTranslator does **not** collect, store, or transmit:
+
+- Personal identification information (name, email, account credentials)
+- Device identifiers or hardware fingerprints
+- Usage history, search history, or translation logs
+- Crash reports or diagnostic telemetry
+- Location data
+
+---
+
+## 3. Third-Party Services
+
+To perform translations, CmdPalTranslator connects to the following external services on your behalf:
+
+| Service | Endpoint | Privacy Policy |
+|---------|----------|----------------|
+| **Microsoft Bing Translator** | `https://www.bing.com/translator` | [Microsoft Privacy Statement](https://privacy.microsoft.com/privacystatement) |
+| **Google Translate** | `https://translate.googleapis.com` | [Google Privacy Policy](https://policies.google.com/privacy) |
+
+When you initiate a translation, your input text and selected language codes are sent directly to the chosen provider. The developer has no control over how these third parties process the data. Please review their respective privacy policies for details.
+
+---
+
+## 4. Internet Connectivity
+
+CmdPalTranslator requires internet access (`internetClient` capability) exclusively to call the Bing and Google translation APIs. No other outbound network connections are made by this application.
+
+---
+
+## 5. Data Retention
+
+- **Translation input** is not retained by the application. Once the translation result is returned and displayed, no copy of the input or output is kept.
+- **Language preference** is stored locally until you change it or uninstall the application.
+
+---
+
+## 6. Children's Privacy
+
+CmdPalTranslator does not knowingly collect any personal information from children under the age of 13. If you believe a child has provided personal data through a translation request, please contact the relevant third-party service directly (Bing or Google) as the data is processed solely by them.
+
+---
+
+## 7. Changes to This Policy
+
+This Privacy Policy may be updated to reflect changes in application functionality or applicable law. Updates will be published in this document with a revised "Last Updated" date. Continued use of the application after an update constitutes acceptance of the revised policy.
+
+---
+
+## 8. Contact
+
+If you have questions or concerns about this Privacy Policy, please open an issue on the project repository:
+
+**GitHub:** [https://github.com/poychang/CmdPalTranslator](https://github.com/poychang/CmdPalTranslator)
+
+---
+
+## 隱私權政策（繁體中文）
+
+**最後更新：** 2026-04-02
+
+CmdPalTranslator 是一個 Windows Command Palette 翻譯擴充功能。本應用程式透過 Bing 與 Google 翻譯服務執行文字翻譯。
+
+### 資料收集與使用
+
+- 您輸入的**文字內容**與**語言設定**會直接傳送至所選的第三方翻譯服務（Bing 或 Google），僅用於執行翻譯。開發者不保留任何翻譯紀錄。
+- 本應用程式僅在您的裝置上本機儲存一項設定：**預設目標語言**（`%LocalAppData%\CmdPalTranslator\default-target-language.txt`）。此設定不會傳送至任何伺服器。
+- 本應用程式**不收集**任何個人識別資訊、裝置識別碼、使用記錄、診斷遙測或位置資料。
+
+### 第三方服務
+
+翻譯請求由 Bing（Microsoft）或 Google 處理。請參閱其各自的隱私權政策：
+
+- [Microsoft 隱私權聲明](https://privacy.microsoft.com/privacystatement)
+- [Google 隱私權政策](https://policies.google.com/privacy)
+
+### 聯絡方式
+
+如有任何疑問，請至 GitHub 開立 Issue：[https://github.com/poychang/CmdPalTranslator](https://github.com/poychang/CmdPalTranslator)


### PR DESCRIPTION
## Why

Submitting to the Microsoft Store requires a publicly accessible Privacy Policy URL. This PR adds `privacy.md` to the repository so it can be hosted (e.g., via GitHub Pages or raw URL) and referenced in Partner Center.

## What's included

The policy accurately reflects how the app works:

- **Data sent to third parties** — source text and language codes are forwarded directly to the Bing and Google translation APIs on the user's behalf; no copy is retained by the app or developer.
- **Local storage** — only the default target language preference is stored on-device in the app's private storage; never transmitted.
- **No telemetry** — explicitly states the app collects no personal identifiers, usage history, crash reports, or location data.
- **Third-party references** — links to Microsoft and Google privacy policies, including API endpoints, so users know where their text goes.
- **Standard sections** — covers Children's Privacy, Data Retention, Changes to Policy, and Contact, satisfying Microsoft Store policy requirements (section 10.5).

## Languages

Both English and Traditional Chinese (繁體中文) sections are included with identical structure and content across all 8 sections.