### PR TITLE
Add Aliyun translator provider with language mapping and tests

### DIFF
--- a/src/CmdPalTranslator.Core/Models/LanguageCatalog.cs
+++ b/src/CmdPalTranslator.Core/Models/LanguageCatalog.cs
@@ -5,12 +5,14 @@
     string DisplayName,
     string GoogleCode,
     string BingCode,
+    string AliyunCode,
     params string[] Aliases)
     {
         public string GetProviderCode(string providerId) => providerId switch
         {
             "google" => GoogleCode,
             "bing" => BingCode,
+            "aliyun" => AliyunCode,
             _ => BingCode,
         };
 
@@ -26,21 +28,21 @@
     {
         private static readonly IReadOnlyList<LanguageOption> Languages =
         [
-            new("auto", "Auto Detect", "auto", "auto-detect", "detect", "default"),
-            new("zhs", "Chinese (Simplified)", "zh-CN", "zh-Hans", "zh-cn", "zh-hans", "simplified chinese"),
-            new("zht", "Chinese (Traditional)", "zh-TW", "zh-Hant", "zh-tw", "zh-hant", "traditional chinese"),
-            new("en", "English", "en", "en", "english"),
-            new("ja", "Japanese", "ja", "ja", "japanese"),
-            new("ko", "Korean", "ko", "ko", "korean"),
-            new("fr", "French", "fr", "fr", "french"),
-            new("de", "German", "de", "de", "german"),
-            new("es", "Spanish", "es", "es", "spanish"),
-            new("it", "Italian", "it", "it", "italian"),
-            new("ru", "Russian", "ru", "ru", "russian"),
-            new("ar", "Arabic", "ar", "ar", "arabic"),
-            new("he", "Hebrew", "iw", "he", "hebrew"),
-            new("pt", "Portuguese", "pt", "pt", "portuguese"),
-            new("th", "Thai", "th", "th", "thai"),
+            new("auto", "Auto Detect", "auto", "auto-detect", "auto", "detect", "default"),
+            new("zhs", "Chinese (Simplified)", "zh-CN", "zh-Hans", "zh", "zh-cn", "zh-hans", "simplified chinese"),
+            new("zht", "Chinese (Traditional)", "zh-TW", "zh-Hant", "zh-TW", "zh-tw", "zh-hant", "traditional chinese"),
+            new("en", "English", "en", "en", "en", "english"),
+            new("ja", "Japanese", "ja", "ja", "ja", "japanese"),
+            new("ko", "Korean", "ko", "ko", "ko", "korean"),
+            new("fr", "French", "fr", "fr", "fr", "french"),
+            new("de", "German", "de", "de", "de", "german"),
+            new("es", "Spanish", "es", "es", "es", "spanish"),
+            new("it", "Italian", "it", "it", "it", "italian"),
+            new("ru", "Russian", "ru", "ru", "ru", "russian"),
+            new("ar", "Arabic", "ar", "ar", "ar", "arabic"),
+            new("he", "Hebrew", "iw", "he", "he", "hebrew"),
+            new("pt", "Portuguese", "pt", "pt", "pt", "portuguese"),
+            new("th", "Thai", "th", "th", "th", "thai"),
         ];
 
         public static IReadOnlyList<LanguageOption> All => Languages;
@@ -69,7 +71,8 @@
 
             if (Languages.FirstOrDefault(item =>
                 string.Equals(item.GoogleCode, idOrCode, StringComparison.OrdinalIgnoreCase)
-                || string.Equals(item.BingCode, idOrCode, StringComparison.OrdinalIgnoreCase)) is { } fromProviderCode)
+                || string.Equals(item.BingCode, idOrCode, StringComparison.OrdinalIgnoreCase)
+                || string.Equals(item.AliyunCode, idOrCode, StringComparison.OrdinalIgnoreCase)) is { } fromProviderCode)
             {
                 return fromProviderCode.DisplayName;
             }

--- a/src/CmdPalTranslator.Core/Providers/AliyunTranslatorProvider.cs
+++ b/src/CmdPalTranslator.Core/Providers/AliyunTranslatorProvider.cs
@@ -1,0 +1,225 @@
+using CmdPalTranslator.Models;
+using System.Diagnostics;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace CmdPalTranslator.Providers
+{
+    internal sealed partial class AliyunTranslatorProvider : ITranslatorProvider
+    {
+        private const string TranslateEndpoint = "https://translate.alibaba.com/api/translate/text";
+        private const string CsrfEndpoint = "https://translate.alibaba.com/api/translate/csrftoken";
+        private const string Referer = "https://translate.alibaba.com/";
+        private const string Origin = "https://translate.alibaba.com";
+        private readonly HttpClient _httpClient;
+        private readonly object _csrfLock = new();
+        private CachedCsrf? _cachedCsrf;
+        private DateTimeOffset _csrfExpiresAt = DateTimeOffset.MinValue;
+
+        public AliyunTranslatorProvider() : this(TranslatorHttpClient.Create()) { }
+
+        internal AliyunTranslatorProvider(HttpClient httpClient)
+        {
+            _httpClient = httpClient;
+            _httpClient.DefaultRequestHeaders.Referrer = new Uri(Referer);
+            _httpClient.DefaultRequestHeaders.TryAddWithoutValidation("Origin", Origin);
+            _httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+        }
+
+        public string Id => "aliyun";
+
+        public string DisplayName => "Aliyun";
+
+        public string Description => "Use the Alibaba Translate web endpoint.";
+
+        public TranslationResponse Translate(ParsedTranslationQuery query, CancellationToken cancellationToken)
+        {
+            string sourceLanguage = query.SourceLanguage.GetProviderCode(Id);
+            string targetLanguage = query.TargetLanguage.GetProviderCode(Id);
+            CachedCsrf csrf = EnsureCsrf(cancellationToken);
+            return SendTranslateRequest(query, sourceLanguage, targetLanguage, csrf, retryOnCsrfFailure: true, cancellationToken);
+        }
+
+        public Uri BuildWebUri(ParsedTranslationQuery query)
+        {
+            string sourceLanguage = query.SourceLanguage.GetProviderCode(Id);
+            string targetLanguage = query.TargetLanguage.GetProviderCode(Id);
+            return new Uri(
+                $"https://translate.alibaba.com/?sourceLanguage={Uri.EscapeDataString(sourceLanguage)}&targetLanguage={Uri.EscapeDataString(targetLanguage)}&sourceText={Uri.EscapeDataString(query.SourceText)}");
+        }
+
+        public void Dispose()
+        {
+            _httpClient.Dispose();
+        }
+
+        private TranslationResponse SendTranslateRequest(
+            ParsedTranslationQuery query,
+            string sourceLanguage,
+            string targetLanguage,
+            CachedCsrf csrf,
+            bool retryOnCsrfFailure,
+            CancellationToken cancellationToken)
+        {
+            using MultipartFormDataContent formData = new()
+            {
+                { new StringContent(sourceLanguage), "srcLang" },
+                { new StringContent(targetLanguage), "tgtLang" },
+                { new StringContent("general"), "domain" },
+                { new StringContent(query.SourceText), "query" },
+                { new StringContent(csrf.Token), "_csrf" },
+            };
+
+            using HttpRequestMessage request = new(HttpMethod.Post, TranslateEndpoint)
+            {
+                Content = formData,
+            };
+
+            using HttpResponseMessage response = _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false).GetAwaiter().GetResult();
+            if (!response.IsSuccessStatusCode)
+            {
+                if (retryOnCsrfFailure && (response.StatusCode == HttpStatusCode.Forbidden || response.StatusCode == HttpStatusCode.Unauthorized))
+                {
+                    InvalidateCsrf();
+                    return SendTranslateRequest(
+                        query,
+                        sourceLanguage,
+                        targetLanguage,
+                        EnsureCsrf(cancellationToken),
+                        retryOnCsrfFailure: false,
+                        cancellationToken);
+                }
+
+                response.EnsureSuccessStatusCode();
+            }
+
+            string content = response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false).GetAwaiter().GetResult();
+            Debug.WriteLine($"Translate response: {content}");
+
+            AliyunTranslatePayload payload = JsonSerializer.Deserialize(content, AliyunJsonContext.Default.AliyunTranslatePayload)
+                ?? throw new InvalidOperationException("Aliyun translation returned an empty response.");
+
+            if (!payload.Success || string.IsNullOrWhiteSpace(payload.Data?.TranslateText))
+            {
+                throw new InvalidOperationException(
+                    $"Aliyun translation returned no translated text. Code: {payload.Code ?? "unknown"}");
+            }
+
+            string translatedText = payload.Data.TranslateText;
+            string detectedLanguage = payload.Data.DetectLanguage ?? query.SourceLanguage.Id;
+            string targetDisplayName = LanguageCatalog.ToDisplayName(query.TargetLanguage.Id);
+
+            return new TranslationResponse(
+                ProviderId: Id,
+                ProviderDisplayName: DisplayName,
+                SourceLanguage: detectedLanguage,
+                TargetLanguage: query.TargetLanguage.Id,
+                SourceText: query.SourceText,
+                Entries:
+                [
+                    new TranslationEntry(
+                        Title: translatedText,
+                        Subtitle: $"{LanguageCatalog.ToDisplayName(detectedLanguage)} -> {targetDisplayName}",
+                        CopyText: translatedText,
+                        Description: $"{translatedText}\n{query.SourceText}",
+                        Category: "Translation"),
+                ],
+                WebUri: BuildWebUri(query));
+        }
+
+        private CachedCsrf EnsureCsrf(CancellationToken cancellationToken)
+        {
+            if (_cachedCsrf is not null && DateTimeOffset.UtcNow < _csrfExpiresAt)
+            {
+                return _cachedCsrf;
+            }
+
+            lock (_csrfLock)
+            {
+                if (_cachedCsrf is not null && DateTimeOffset.UtcNow < _csrfExpiresAt)
+                {
+                    return _cachedCsrf;
+                }
+
+                using HttpRequestMessage request = new(HttpMethod.Get, CsrfEndpoint);
+                using HttpResponseMessage response = _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false).GetAwaiter().GetResult();
+                response.EnsureSuccessStatusCode();
+
+                string content = response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false).GetAwaiter().GetResult();
+                AliyunCsrfPayload payload = JsonSerializer.Deserialize(content, AliyunJsonContext.Default.AliyunCsrfPayload)
+                    ?? throw new InvalidOperationException("Aliyun CSRF endpoint returned an empty response.");
+
+                if (string.IsNullOrWhiteSpace(payload.Token) || string.IsNullOrWhiteSpace(payload.HeaderName))
+                {
+                    throw new InvalidOperationException("Aliyun CSRF endpoint did not return the required authentication metadata.");
+                }
+
+                if (_cachedCsrf is not null && _httpClient.DefaultRequestHeaders.Contains(_cachedCsrf.HeaderName))
+                {
+                    _httpClient.DefaultRequestHeaders.Remove(_cachedCsrf.HeaderName);
+                }
+
+                _cachedCsrf = new CachedCsrf(payload.Token, payload.HeaderName);
+                _httpClient.DefaultRequestHeaders.Remove(payload.HeaderName);
+                _httpClient.DefaultRequestHeaders.TryAddWithoutValidation(payload.HeaderName, payload.Token);
+                _csrfExpiresAt = DateTimeOffset.UtcNow.AddMinutes(20);
+                return _cachedCsrf;
+            }
+        }
+
+        private void InvalidateCsrf()
+        {
+            lock (_csrfLock)
+            {
+                if (_cachedCsrf is not null)
+                {
+                    _httpClient.DefaultRequestHeaders.Remove(_cachedCsrf.HeaderName);
+                }
+
+                _cachedCsrf = null;
+                _csrfExpiresAt = DateTimeOffset.MinValue;
+            }
+        }
+
+        private sealed record CachedCsrf(string Token, string HeaderName);
+
+        private sealed class AliyunCsrfPayload
+        {
+            [JsonPropertyName("token")]
+            public string? Token { get; set; }
+
+            [JsonPropertyName("headerName")]
+            public string? HeaderName { get; set; }
+        }
+
+        private sealed class AliyunTranslatePayload
+        {
+            [JsonPropertyName("code")]
+            public string? Code { get; set; }
+
+            [JsonPropertyName("success")]
+            public bool Success { get; set; }
+
+            [JsonPropertyName("data")]
+            public AliyunTranslateData? Data { get; set; }
+        }
+
+        private sealed class AliyunTranslateData
+        {
+            [JsonPropertyName("detectLanguage")]
+            public string? DetectLanguage { get; set; }
+
+            [JsonPropertyName("translateText")]
+            public string? TranslateText { get; set; }
+        }
+
+        // 使用 NativeAOT 建置應用程式時，會需要標註序列化會涉及的型別，讓應用程式可以正確序列化和反序列化這些型別。
+        [JsonSourceGenerationOptions(JsonSerializerDefaults.Web)]
+        [JsonSerializable(typeof(AliyunCsrfPayload))]
+        [JsonSerializable(typeof(AliyunTranslatePayload))]
+        [JsonSerializable(typeof(AliyunTranslateData))]
+        private sealed partial class AliyunJsonContext : JsonSerializerContext { }
+    }
+}

--- a/src/CmdPalTranslator.Tests/LiveTranslationProviderTests.cs
+++ b/src/CmdPalTranslator.Tests/LiveTranslationProviderTests.cs
@@ -13,6 +13,7 @@ namespace CmdPalTranslator.Tests
         [TestMethod]
         [DataRow("Bing")]
         [DataRow("Google")]
+        [DataRow("Aliyun")]
         public void ProvidersTranslateBetweenTraditionalChineseAndEnglish(string providerId)
         {
             using ITranslatorProvider provider = CreateProvider(providerId);
@@ -53,6 +54,7 @@ namespace CmdPalTranslator.Tests
         {
             "Bing" => new BingTranslatorProvider(),
             "Google" => new GoogleTranslatorProvider(),
+            "Aliyun" => new AliyunTranslatorProvider(),
             _ => throw new ArgumentOutOfRangeException(nameof(providerId), providerId, "Unknown provider."),
         };
 

--- a/src/CmdPalTranslator.Tests/ProviderTranslationUnitTests.cs
+++ b/src/CmdPalTranslator.Tests/ProviderTranslationUnitTests.cs
@@ -130,6 +130,82 @@ namespace CmdPalTranslator.Tests
             Assert.IsTrue(requestUris.Any(uri => uri.Contains("sl=en", StringComparison.Ordinal) && uri.Contains("tl=zh-TW", StringComparison.Ordinal)));
         }
 
+        [TestMethod]
+        public void AliyunProviderTranslatesTraditionalChineseAndEnglish()
+        {
+            int csrfRequests = 0;
+            List<Dictionary<string, string>> formPayloads = [];
+            List<string?> csrfHeaders = [];
+
+            using HttpClient httpClient = new(new StubHttpMessageHandler(request =>
+            {
+                if (request.Method == HttpMethod.Get)
+                {
+                    csrfRequests++;
+                    return new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent("""
+                    {
+                      "token": "aliyun-csrf-token",
+                      "headerName": "x-csrf-token"
+                    }
+                    """, Encoding.UTF8, "application/json"),
+                    };
+                }
+
+                formPayloads.Add(ReadFormValues(request));
+                request.Headers.TryGetValues("x-csrf-token", out IEnumerable<string>? headerValues);
+                csrfHeaders.Add(headerValues?.FirstOrDefault());
+
+                bool isZhToEn = formPayloads[^1]["query"] == "蘋果";
+                string translatedText = isZhToEn ? "apple" : "蘋果";
+                string detectedLanguage = isZhToEn ? "zh-TW" : "en";
+
+                string json = $$"""
+            {
+              "code": "200",
+              "success": true,
+              "data": {
+                "detectLanguage": "{{detectedLanguage}}",
+                "translateText": "{{translatedText}}"
+              }
+            }
+            """;
+
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(json, Encoding.UTF8, "application/json"),
+                };
+            }));
+
+            using AliyunTranslatorProvider provider = new(httpClient);
+
+            TranslationResponse zhToEn = provider.Translate(
+                CreateQuery("蘋果", sourceLanguageId: "zht", targetLanguageId: "en"),
+                CancellationToken.None);
+
+            TranslationResponse enToZh = provider.Translate(
+                CreateQuery("apple", sourceLanguageId: "en", targetLanguageId: "zht"),
+                CancellationToken.None);
+
+            CollectionAssert.Contains([.. zhToEn.Entries.Select(entry => entry.Title)], "apple", StringComparer.OrdinalIgnoreCase);
+            CollectionAssert.Contains([.. enToZh.Entries.Select(entry => entry.Title)], "蘋果");
+            Assert.AreEqual(1, csrfRequests);
+
+            Assert.AreEqual("zh-TW", formPayloads[0]["srcLang"]);
+            Assert.AreEqual("en", formPayloads[0]["tgtLang"]);
+            Assert.AreEqual("en", formPayloads[1]["srcLang"]);
+            Assert.AreEqual("zh-TW", formPayloads[1]["tgtLang"]);
+
+            foreach (Dictionary<string, string> payload in formPayloads)
+            {
+                Assert.AreEqual("general", payload["domain"]);
+                Assert.AreEqual("aliyun-csrf-token", payload["_csrf"]);
+            }
+
+            Assert.IsTrue(csrfHeaders.All(value => string.Equals(value, "aliyun-csrf-token", StringComparison.Ordinal)));
+        }
+
         private static ParsedTranslationQuery CreateQuery(string text, string sourceLanguageId, string targetLanguageId)
         {
             return new ParsedTranslationQuery(


### PR DESCRIPTION
## Why
CmdPalTranslator currently supports Bing and Google only. This change adds Aliyun as another live translation provider and aligns language-code mapping so provider-specific codes are managed centrally.

## What changed
- Added `AliyunTranslatorProvider` that calls Alibaba Translate endpoints:
  - `GET /api/translate/csrftoken` for CSRF metadata
  - `POST /api/translate/text` for translation
- Implemented CSRF token caching, header injection, retry on auth-related failure, and response parsing into existing `TranslationResponse`/`TranslationEntry` models.
- Extended `LanguageOption` with `AliyunCode` and updated `GetProviderCode("aliyun")` so Aliyun language code handling lives in `LanguageCatalog`.
- Updated language catalog entries for Aliyun mappings (for example `auto`, `zh`, `zh-TW`).
- Updated integration live-provider coverage to include Aliyun in `LiveTranslationProviderTests`.
- Added unit coverage for Aliyun provider request/response behavior in `ProviderTranslationUnitTests`.

## Notes for reviewers
- Aliyun-specific language normalization that was previously inside the provider is intentionally removed and centralized in `LanguageCatalog`.
- Existing `dotnet test` invocation in this environment still depends on MTP/VSTest configuration behavior; the code changes compile successfully.